### PR TITLE
[RB-3141] Change how the url is generated due to scanner

### DIFF
--- a/Tests/Common/MongoDB/MongoDBUtilityTest.php
+++ b/Tests/Common/MongoDB/MongoDBUtilityTest.php
@@ -65,11 +65,12 @@ class MongoDBUtilityTest extends \PHPUnit_Framework_TestCase
     
     public function test_extractParametersFromServerString_passingStringWithMultipleHostnamesAndUsernameAndPasswords_returnsCorrectParametersForTheFirstHostnameAndUsernameAndPassword()
     {
-        $serverString = 'mongodb://username:password@127.0.0.1:1234,username:password@127.0.0.1:1235';
         $parsedHostnameShouldBe = '127.0.0.1:1234';
         $parsedUsernameShouldBe = 'username';
         $parsedPasswordShouldBe = 'password';
-        
+
+        $serverString = "mongodb://{$parsedUsernameShouldBe}:{$parsedPasswordShouldBe}@127.0.0.1:1234,{$parsedUsernameShouldBe}:{$parsedPasswordShouldBe}@127.0.0.1:1235";
+
         $parameters = $this->utilityInstance->extractParametersFromServerString($serverString);
         
         $this->assertInternalType('array', $parameters);


### PR DESCRIPTION
Due to how the security scanning finds passwords it was marking this as a password in code. To fix that I used the values to build the connection string vs hardcoding it. 